### PR TITLE
Doc: Update obsolete external URLs

### DIFF
--- a/doc/src/declarative/declarativeui.qdoc
+++ b/doc/src/declarative/declarativeui.qdoc
@@ -84,8 +84,8 @@ Qt applications.
 \list
 \o \l{Qt Quick Components for Symbian 1.1}{Qt Quick Components for Symbian} - a native component set for the Symbian^3 platform
 \o \l{QtWebKit QML Module}
-\o \l{http://doc.qt.nokia.com/qtmobility-1.1.0/qml-plugins.html}{Mobility QML Plugins}
-\o \l {http://doc.qt.nokia.com/qt-components-symbian-1.1/index.html}{Qt Quick Components}
+\o \l{http://doc.qt.digia.com/qtmobility-1.1.0/qml-plugins.html}{Mobility QML Plugins}
+\o \l {http://doc.qt.digia.com/qt-components-symbian-1.0/index.html}{Qt Quick Components}
 \endlist
 
 \section1 Qt Quick Tools
@@ -106,7 +106,7 @@ Qt applications.
 \o \l{QML Coding Conventions}
 \o \l{external: Qt Creator Manual}{Qt Creator Manual}
 \o \l{Programming with Qt}
-\o \l{http://doc.qt.nokia.com/qtmobility-1.1.0/index.html}{Qt Mobility Documentation}
+\o \l{http://doc.qt.digia.com/qtmobility-1.1.0/index.html}{Qt Mobility Documentation}
 \endlist
 
 \section1 Architecture

--- a/doc/src/declarative/elements.qdoc
+++ b/doc/src/declarative/elements.qdoc
@@ -185,8 +185,8 @@ These elements are not included in the \c{QtQuick 1.0} module. Their respective 
 should first be obtained and installed.
 \list
 \o \l{WebView}{QtWebKit QML Module - WebView Element} - For displaying Web contents
-\o \l{http://doc.qt.nokia.com/qtmobility-1.1.0/qml-plugins.html}{Mobility QML Plugins}
-\o \l {http://doc.qt.nokia.com/qt-components-symbian-1.1/index.html}{Qt Quick Components}
+\o \l{http://doc.qt.digia.com/qtmobility-1.1.0/qml-plugins.html}{Mobility QML Plugins}
+\o \l {http://doc.qt.digia.com/qt-components-symbian-1.0/index.html}{Qt Quick Components}
 \endlist
 
 */

--- a/doc/src/declarative/qdeclarativedebugging.qdoc
+++ b/doc/src/declarative/qdeclarativedebugging.qdoc
@@ -78,7 +78,7 @@ QDeclarativeImportDatabase::resolveType "Rectangle" = "QDeclarativeRectangle"
 
 \section1 Debugging with Qt Creator
 
-\l{http://qt.nokia.com/products/developer-tools}{Qt Creator} provides built-in
+\l{http://doc.qt.io/qtcreator/creator-debugging-qml.html}{Qt Creator} provides built-in
 support for QML debugging. QML projects and standalone C++ applications that
 utilize QML can be debugged on desktops as well as on remote devices.
 For more information, see the Qt Creator Manual.

--- a/doc/src/examples/codeeditor.qdoc
+++ b/doc/src/examples/codeeditor.qdoc
@@ -192,7 +192,7 @@
     fetched with QTextBlock::userData(). Matching parentheses can be
     highlighted with an extra selection. The "Matching Parentheses
     with QSyntaxHighlighter" article in Qt Quarterly 31 implements
-    this. You find it here: \l{http://doc.qt.nokia.com/qq/}.
+    this. You find it here: \l{http://doc.qt.digia.com/qq/}.
 
     The line number area is now painted every time the cursor blinks
     (because we connect \l{QPlainTextEdit::}{updateRequest()} to

--- a/doc/src/examples/syntaxhighlighter.qdoc
+++ b/doc/src/examples/syntaxhighlighter.qdoc
@@ -245,7 +245,7 @@
     It is possible to implement parenthesis matching with
     QSyntaxHighlighter. The "Matching Parentheses with
     QSyntaxHighlighter" article in Qt Quarterly 31
-    (\l{http://doc.qt.nokia.com/qq/}) implements this. We also have
+    (\l{http://doc.qt.digia.com/qq/}) implements this. We also have
     the \l{Code Editor Example}, which shows how to implement line
     numbers and how to highlight the current line.
 

--- a/doc/src/files-and-resources/resources.qdoc
+++ b/doc/src/files-and-resources/resources.qdoc
@@ -54,7 +54,7 @@
     The resource system is based on tight cooperation between \l qmake,
     \l rcc (Qt's resource compiler), and QFile. It obsoletes Qt 3's
     \c qembed tool and the
-    \l{http://qt.nokia.com/doc/qq/qq05-iconography.html#imagestorage}{image
+    \l{http://doc.qt.digia.com/qq/qq05-iconography.html#imagestorage}{image
     collection} mechanism.
 
     \section1 Resource Collection Files (\c{.qrc})

--- a/doc/src/frameworks-technologies/eventsandfilters.qdoc
+++ b/doc/src/frameworks-technologies/eventsandfilters.qdoc
@@ -100,7 +100,7 @@
     event delivery mechanisms are flexible. The documentation for
     QCoreApplication::notify() concisely tells the whole story; the
     \e{Qt Quarterly} article
-    \l{http://doc.qt.nokia.com/qq/qq11-events.html}{Another Look at Events}
+    \l{http://doc.qt.digia.com/qq/qq11-events.html}{Another Look at Events}
     rehashes it less concisely. Here we will explain enough for 95%
     of applications.
 

--- a/doc/src/getting-started/installation.qdoc
+++ b/doc/src/getting-started/installation.qdoc
@@ -1348,7 +1348,7 @@ We hope you will enjoy using Qt.
     \endlist
 
 
-    We recommend you to take a look at \l{http://doc.qt.nokia.com/latest/install-symbian.html}{Installing Qt for the Symbian platform}
+    We recommend you to take a look at \l{http://doc.qt.digia.com/latest/install-symbian.html}{Installing Qt for the Symbian platform}
     to get more information about how to setup the development environment.
 
     \sa {Known Issues}

--- a/doc/src/getting-started/known-issues.qdoc
+++ b/doc/src/getting-started/known-issues.qdoc
@@ -32,7 +32,7 @@
     \brief Links to online resources stating known issues in this Qt version at the time of release.
 
 	\list
-        \o An up-to-date list of known issues can be found at \l{http://bugreports.qt-project.org/}{Qt Bug Tracker}.
+        \o An up-to-date list of known issues can be found at \l{http://bugreports.qt.io/}{Qt Bug Tracker}.
 	\o For a list list of known bugs, see the \l{Task Tracker} at the Qt website.
 	\o An overview of known issues may also be found at: \l{http://qt.gitorious.org/qt/pages/QtKnownIssues}
     {Known Issues Wiki}.

--- a/doc/src/internationalization/linguist-manual.qdoc
+++ b/doc/src/internationalization/linguist-manual.qdoc
@@ -1421,8 +1421,8 @@
     \c -pluralonly command line option, which allows the creation of
     TS files containing only entries with plural forms.
 
-    See the \l{http://doc.qt.nokia.com/qq/}{Qt Quarterly} Article
-    \l{http://doc.qt.nokia.com/qq/qq19-plurals.html}{Plural Forms in Translations}
+    See the \l{http://doc.qt.digia.com/qq/}{Qt Quarterly} Article
+    \l{http://doc.qt.digia.com/qq/qq19-plurals.html}{Plural Forms in Translations}
     for further details on this issue.
 
     \section2 Coping With C++ Namespaces

--- a/doc/src/platforms/emb-fonts.qdoc
+++ b/doc/src/platforms/emb-fonts.qdoc
@@ -47,8 +47,7 @@
     legacy \c lib/fonts/fontdir file.
 
     Support for other font formats can be added. To make a suggestion,
-    please create a task in our bug tracker at \l
-    {http://bugreports.qt-project.org}{http://bugreports.qt-project.org}.
+    please create a task in our \l {Qt Bug Tracker}{bug tracker}.
 
     \tableofcontents
 

--- a/doc/src/platforms/platform-notes.qdoc
+++ b/doc/src/platforms/platform-notes.qdoc
@@ -65,7 +65,7 @@
 
     This page describes implementation details regarding the Qt for Symbian port. To get 
     started with application development for Symbian devices, read  the \l 
-    {http://doc.qt.nokia.com/qtcreator/creator-developing-symbian.html} 
+    {external: Setting Up Development Environment for Symbian}
     {Connecting Symbian Devices} document.
 
     \section1 Source Compatibility
@@ -95,7 +95,7 @@
     \target Supported Devices
     \section1 Supported Devices
     
-    The \l {http://developer.qt.nokia.com/wiki/support_for_Symbian}{Support for Symbian} document
+    The \l {http://wiki.qt.io/Support_for_Symbian}{Support for Symbian} document
     details the Qt support on different Symbian devices.
 
     The \l {http://www.developer.nokia.com/Community/Wiki/Nokia_Smart_Installer_for_Symbian#Supported_Devices}
@@ -124,7 +124,7 @@
     \list
     \o QtConcurrent
     \o QtDBus
-    \o \l {http://doc.qt.nokia.com/4.8/printing.html}{Printing support}
+    \o \l {http://doc.qt.io/qt-4.8/printing.html}{Printing support}
     \o Qt3Support
     \endlist
     
@@ -141,7 +141,7 @@
     \row    \o QtGui
             \o QtGui's widgets are deprecated (i.e. they are available but not 
             recommended to use) in the Symbian port. It is recommended to use \l
-            {http://doc.qt.nokia.com/qt-components-symbian-1.1/symbian-components-functional.html}
+            {http://doc.qt.digia.com/qt-components-symbian-1.0/symbian-components-functional.html}
             {Qt Quick Components for Symbian} instead, because they provide 
             better look and feel on Symbian devices.
 
@@ -186,9 +186,9 @@
     Known issues can be found by visiting the
     \l{http://qt.gitorious.org/qt/pages/QtKnownIssues}{wiki page} with an
     up-to-date list of known issues, and the list of bugs can be found by
-    \l{http://bugreports.qt-project.org/browse/QTBUG/component/19171}{browsing} the
+    \l{http://bugreports.qt.io/browse/QTBUG/component/19171}{browsing} the
     S60 component in Qt's public task tracker, located at
-    \l{http://bugreports.qt-project.org/}{http://bugreports.qt-project.org/}.
+    \l{http://bugreports.qt.io/}{http://bugreports.qt.io/}.
 
     For information about mixing exceptions with Symbian leaves, see
     \l{Exception Safety with Symbian}.
@@ -200,7 +200,7 @@
     capabilities to function properly. The capabilities your application needs
     to function properly depends on which parts of Qt you use. 
     In a Qt application Symbian capabilities are defined in the
-    \l {http://doc.qt.nokia.com/4.8/qmake-variable-reference.html#target-capability}
+    \l {http://doc.qt.io/qt-4.8/qmake-variable-reference.html#target-capability}
     {TARGET.CAPABILITY} qmake variable in the project file.
     Here is an overview for which capabilities may be needed when using different modules:
 
@@ -236,7 +236,7 @@
     \section1 Multimedia Support
 
     Qt Mobility provides a high-level API for multimedia functionality with
-    \l{http://doc.qt.nokia.com/qtmobility/multimedia.html}{QtMultimediaKit}.
+    \l{http://doc.qt.digia.com/qtmobility/multimedia.html}{QtMultimediaKit}.
     In addition, Qt provides the low-level \l {QtMultimedia}{QtMultimedia} 
     module that is internally used by the QtMultimediaKit. For more information
     on developing multimedia applications for Symbian devices, see
@@ -295,7 +295,7 @@
     Symbian. The OpenVG graphics system is not able to manage OpenGL graphics
     resources. Also, a QGLWidget object is not able to release its GPU resources
     when the application goes to the background. If OpenGL functionality is
-    needed, \l { http://doc.qt.nokia.com/4.7-snapshot/qapplication.html#setGraphicsSystem}
+    needed, \l {http://doc.qt.io/qt-4.8/qapplication.html#setGraphicsSystem}
     {OpenGL graphics system} usage is recommended. If an application
     decides to use QGLWidget, then it is the application's responsibility to
     destroy and release QGLWidget and related OpenGL resources when the

--- a/doc/src/platforms/supported-platforms.qdoc
+++ b/doc/src/platforms/supported-platforms.qdoc
@@ -91,7 +91,7 @@
 
     \section2 Cross-Platform Development using Qt Creator
 
-    \l{http://doc.qt.nokia.com/qtcreator-snapshot/index.html}{Qt Creator} is
+    \l{http://doc.qt.io/qtcreator/index.html}{Qt Creator} is
     a complete Cross-platform IDE included in the Qt SDK. The IDE allows
     programmers to create, build, debug and run Qt applications accross all
     supported platforms.
@@ -157,7 +157,7 @@
 
     \section2 Cross-Platform Development using Qt Creator
 
-    \l{http://doc.qt.nokia.com/qtcreator-snapshot/index.html}{Qt Creator} is
+    \l{http://doc.qt.io/qtcreator/index.html}{Qt Creator} is
     a complete Cross-platform IDE included in the Qt SDK. The IDE allows
     programmers to create, build, debug and run Qt applications accross all
     supported platforms.
@@ -240,7 +240,7 @@
 
     \section2 Cross-Platform Development using Qt Creator
 
-    \l{http://doc.qt.nokia.com/qtcreator-snapshot/index.html}{Qt Creator} is
+    \l{http://doc.qt.io/qtcreator/index.html}{Qt Creator} is
     a complete Cross-platform IDE included in the Qt SDK. The IDE allows
     programmers to create, build, debug and run Qt applications accross all
     supported platforms.

--- a/doc/src/porting/porting4.qdoc
+++ b/doc/src/porting/porting4.qdoc
@@ -173,7 +173,7 @@
     and MSVC 7.)
 
     If you get stuck, ask on the
-    \l{http://qt.nokia.com/lists/qt-interest/}{qt-interest}
+    \l{http://lists.qt-project.org/mailman/listinfo/interest}{qt-interest}
     mailing list. If you are a licensed customer, you can also contact
     Qt's technical support team.
 
@@ -472,7 +472,7 @@
     \section1 Explicit Sharing
 
     Qt 4 is the first version of Qt that contains no \link
-    http://doc.qt.nokia.com/3.3/shclass.html explicitly shared
+    http://doc.qt.digia.com/3.3/shclass.html explicitly shared
     \endlink classes. All classes that were explicitly shared in Qt 3
     are \e implicitly shared in Qt 4:
 
@@ -1079,7 +1079,7 @@
     ensuring that the string is '\\0'-terminated. Another important
     issue was that conversions between \c QCString and QByteArray often
     gave confusing results. (See the
-    \l{http://doc.qt.nokia.com/qq/qq05-achtung.html#qcstringisastringofchars}{Achtung!
+    \l{http://doc.qt.digia.com/qq/qq05-achtung.html#qcstringisastringofchars}{Achtung!
     Binary and Character Data} article in \e{Qt Quarterly} for an
     overview of the pitfalls.)
 
@@ -2440,13 +2440,13 @@
     that provides the old semantics. See the Q3Painter documentation
     for details and for the reasons why we had to make this change.
 
-    The \l{http://doc.qt.nokia.com/3.3/qpainter.html#CoordinateMode-enum}{QPainter::CoordinateMode}
+    The \l{http://doc.qt.digia.com/3.3/qpainter.html#CoordinateMode-enum}{QPainter::CoordinateMode}
     enum has been removed in Qt 4. All clipping
     operations are now defined using logical coordinates and are subject
     to transformation operations.
 
     The
-    \l{http://doc.qt.nokia.com/3.3/qpainter.html#RasterOP-enum}{QPainter::RasterOP}
+    \l{http://doc.qt.digia.com/3.3/qpainter.html#RasterOP-enum}{QPainter::RasterOP}
     enum has been replaced with QPainter::CompositionMode.
 
     \section1 QPicture
@@ -3258,7 +3258,7 @@
 
     \list \o If you use Q3SocketDevice in a thread to perform blocking
     network I/O (a technique encouraged by the \e{Qt Quarterly}
-    article \l{http://doc.qt.nokia.com/qq/qq09-networkthread.html}
+    article \l{http://doc.qt.digia.com/qq/qq09-networkthread.html}
     {Unblocking Networking}), you can now use QTcpSocket, QFtp, or
     QNetworkAccessManager, which can be used from non-GUI threads.
 
@@ -4052,7 +4052,7 @@
 
     Sample code on how to do obtain similar behavior from Qt 4, previously
     handled by some of the above functions can be found in the
-    \l{http://doc.qt.nokia.com/qwidget-qt3.html}{Qt 3 Support Members for QWidget}
+    \l{http://doc.qt.digia.com/4.0/qwidget-qt3.html}{Qt 3 Support Members for QWidget}
     page.
 
     A widget now receives change events in its QWidget::changeEvent()
@@ -4150,7 +4150,7 @@
     clearWFlags() has no direct replacement. You can use
     QWidget::setAttribute() instead. For example,
     \c{setAttribute(..., false)} to clear an attribute. More information
-    is available \l{http://doc.qt.nokia.com/qwidget.html#setAttribute}{here}.
+    is available \l{http://doc.qt.io/qt-4.8/qwidget.html#setAttribute}{here}.
 
     testWFlags() was renamed to \l{QWidget::testAttribute()}{testAttribute()}.
 

--- a/doc/src/qt-webpages.qdoc
+++ b/doc/src/qt-webpages.qdoc
@@ -26,27 +26,27 @@
 ****************************************************************************/
 
 /*!
-    \externalpage http://qt-project.org/
+    \externalpage http://www.qt.io/
     \title Qt Homepage
 */
 /*!
-    \externalpage http://bugreports.qt-project.org
+    \externalpage http://bugreports.qt.io/
     \title Qt Bug Tracker
 */
 /*!
-    \externalpage http://qt.digia.com/Product/
+    \externalpage http://www.qt.io/product/
     \title About Qt
 */
 /*!
-    \externalpage http://qt.digia.com/Product/Developer-Tools/
+    \externalpage http://www.qt.io/ide/
     \title Visual Studio Integration
 */
 /*!
-    \externalpage http://qt.digia.com/Product/Developer-Tools/
+    \externalpage http://www.qt.io/ide/
     \title Qt Creator Product Page
 */
 /*!
-    \externalpage http://qt.digia.com/products/add-on-products/catalog/4/Utilities/qtcorba/
+    \externalpage http://www.qt.io/product/
     \title CORBA Framework
 */
 /*!
@@ -54,11 +54,11 @@
     \title Window Menu
 */
 /*!
-    \externalpage http://qt-project.org
+    \externalpage http://www.qt.io/developers/
     \title Developer Network
 */
 /*!
-    \externalpage http://qt.digia.com/downloads
+    \externalpage http://www.qt.io/download
     \title Downloads
 */
 /*!
@@ -66,27 +66,27 @@
     \title License FAQ
 */
 /*!
-    \externalpage http://qt.digia.com/products/licensing/
+    \externalpage http://www.qt.io/terms-conditions/#section-1
     \title Free Software and Contributions
 */
 /*!
-    \externalpage http://qt.digia.com/products/licensing/
+    \externalpage http://www.qt.io/terms-conditions/#section-1
     \title Qt Licensing Overview
 */
 /*!
-    \externalpage http://qt.digia.com/products/licensing/
+    \externalpage http://www.qt.io/download/
     \title Qt License Pricing
 */
 /*!
-    \externalpage http://qt-project.org/doc/qt-4.8/supported-platforms.html
+    \externalpage http://doc.qt.io/qt-4.8/supported-platforms.html
     \title Platform Support Policy
 */
 /*!
-    \externalpage http://qt.digia.com/product/
+    \externalpage http://www.qt.io/product/
     \title Product Overview
 */
 /*!
-    \externalpage http://qt-project.org/doc/qt-4.8/supported-platforms.html
+    \externalpage http://doc.qt.io/qt-4.8/supported-platforms.html
     \title Qt 4 Platforms Overview
 */
 /*!
@@ -94,7 +94,7 @@
     \title Qt Quarterly
 */
 /*!
-    \externalpage http://bugreports.qt-project.org
+    \externalpage http://bugreports.qt.io/
     \title Task Tracker
 */
 /*!
@@ -102,19 +102,19 @@
     \title Qt Mailing Lists
 */
 /*!
-    \externalpage http://qt-project.org/wiki/Category:Learning::Whitepapers
+    \externalpage https://wiki.qt.io/Category:Learning::Whitepapers
     \title Whitepapers
 */
 /*!
-    \externalpage http://qt.digia.com/product/
+    \externalpage http://www.qt.io/product/
     \title QtCanvas
 */
 /*!
-    \externalpage http://blog.qt.digia.com/2007/08/10/qt-d-bus-accessibility-bridge-on-labstrolltechcom/
+    \externalpage http://blog.qt.io/blog/2007/08/10/qt-d-bus-accessibility-bridge-on-labstrolltechcom/
     \title D-Bus Accessibility Bridge
 */
 /*!
-    \externalpage http://blog.qt.digia.com/2008/12/05/qtestlib-now-with-nice-graphs-pointing-upwards/
+    \externalpage http://blog.qt.io/blog/2008/12/05/qtestlib-now-with-nice-graphs-pointing-upwards/
     \title qtestlib-tools Announcement
 */
 /*!
@@ -126,7 +126,7 @@
     \title QtSharedMemory
 */
 /*!
-    \externalpage http://qt.digia.com/qq/qq21-portingcanvas.html
+    \externalpage http://doc.qt.digia.com/qq/qq21-portingcanvas.html
     \title Porting to Qt 4.2's Graphics View
 */
 /*!
@@ -134,7 +134,7 @@
     \title QtWinForms Solution
 */
 /*!
-    \externalpage http://qt.gitorious.org
+    \externalpage https://code.qt.io/
     \title Public Qt Repository
 */
 /*!
@@ -146,51 +146,51 @@
     \title qtestlib-tools
 */
 /*!
-    \externalpage http://
+    \externalpage http://doc.qt.io/
     \title Qt Docs Web Start Page
 */
 /*!
-    \externalpage http://qt-project.org/doc/qtcreator-2.5/creator-visual-editor.html
+    \externalpage http://doc.qt.io/qtcreator/creator-visual-editor.html
     \title external: Developing Qt Quick Applications with Creator
 */
 /*!
-    \externalpage http://qt-project.org/wiki/Qt_Coding_Style
+    \externalpage https://wiki.qt.io/Qt_Coding_Style
     \title Qt Coding Style
 */
 /*!
-    \externalpage http://qt-project.org/forums
+    \externalpage http://forum.qt.io/
     \title Forums on Qt Developer Network
 */
 /*!
-    \externalpage http://qt-project.org/wiki/
+    \externalpage https://wiki.qt.io/Main_Page
     \title Wiki on Qt Developer Network
 */
 /*!
-    \externalpage http://qt-project.org/wiki/QtCreatorWhitepaper
+    \externalpage https://wiki.qt.io/QtCreatorWhitepaper
     \title Qt Creator Whitepaper
 */
 /*!
-    \externalpage http://qt-project.org/wiki/Category:Learning::Whitepaper
+    \externalpage https://wiki.qt.io/Category:Learning::Whitepapers
     \title Qt Whitepaper
 */
 /*!
-    \externalpage http://qt-project.org/doc/qtcreator-2.5/creator-visual-editor.html
+    \externalpage http://doc.qt.io/qtcreator/creator-visual-editor.html
     \title external: Developing Qt Quick Applications
 */
 /*!
-    \externalpage http://qt-project.org/doc/qtcreator-2.5/creator-publish-ovi.html
+    \externalpage http://doc.qt.io/qtcreator/creator-deployment.html
     \title external: Publishing Applications to Ovi Store
 */
 /*!
-    \externalpage http://qt-project.org/doc/qtcreator-2.5/
+    \externalpage http://doc.qt.io/qtcreator/
     \title external: Qt Creator Manual
 */
 /*!
-    \externalpage http://qt-project.org/doc/qtcreator-2.5/creator-developing-symbian.html
+    \externalpage http://doc.qt.digia.com/qtcreator-2.4/creator-developing-symbian.html
     \title external: Setting Up Development Environment for Symbian
 */
 /*!
-    \externalpage http://qt-project.org/doc/qtcreator-2.5/creator-developing-maemo.html
+    \externalpage http://doc.qt.digia.com/qtcreator-2.4/creator-developing-maemo.html
     \title external: Setting Up Development Environment for Maemo
 */
 /*!
@@ -206,7 +206,7 @@
     \title external: Qt Simulator Manual
 */
 /*!
-    \externalpage http://qt.digia.com/Product/Qt-SDK/
+    \externalpage http://www.qt.io/product/
     \title Qt SDK Product Page
 */
 /*!
@@ -214,39 +214,39 @@
     \title external: Qt SDK Manual
 */
 /*!
-    \externalpage http://qt-project.org/doc/qtcreator-2.5/creator-project-managing.html
+    \externalpage http://doc.qt.io/qtcreator/creator-project-managing.html
     \title external: Creating Qt Projects in Creator
 */
 /*!
-    \externalpage http://qt-project.org/doc/qtcreator-2.5/creator-building-running.html
+    \externalpage http://doc.qt.io/qtcreator/creator-building-running.html
     \title external: Building and Running Applications in Creator
 */
 /*!
-    \externalpage http://qt-project.org/doc/qtcreator-2.5/creator-running-targets.html
+    \externalpage http://doc.qt.io/qtcreator/creator-running-targets.html
     \title external: Set Compiler Targets in Creator
 */
 /*!
-    \externalpage http://qt-project.org/doc/qtcreator-2.5/creator-build-settings.html
+    \externalpage http://doc.qt.io/qtcreator/creator-build-settings.html
     \title external: Build Settings in Creator
 */
 /*!
-    \externalpage http://qt-project.org/doc/qtcreator-2.5/creator-run-settings.html
+    \externalpage http://doc.qt.io/qtcreator/creator-run-settings.html
     \title external: Run Settings in Creator
 */
 /*!
-    \externalpage http://qt-project.org/doc/qtcreator-2.5/creator-using-qt-designer.html
+    \externalpage http://doc.qt.io/qtcreator/creator-using-qt-designer.html
     \title external: Designer in Creator
 */
 /*!
-    \externalpage http://qt-project.org/doc/qtcreator-2.5/creator-debugging.html
+    \externalpage http://doc.qt.io/qtcreator/creator-debugging.html
     \title external: Debugging Applications in Creator
 */
 /*!
-    \externalpage http://qt-project.org/doc/qtcreator-2.5/creator-deployment-symbian.html
+    \externalpage http://doc.qt.digia.com/qtcreator-2.4/creator-deployment-symbian.html
     \title external: Symbian Deployment in Creator
 */
 /*!
-    \externalpage http://qt-project.org/doc/qtcreator-2.5/creator-deployment-maemo.html
+    \externalpage http://doc.qt.digia.com/qtcreator-2.4/creator-deployment-maemo.html
     \title external: Maemo Deployment in Creator
 */
 /*!
@@ -258,11 +258,11 @@
     \title external: Mobility Location
 */
 /*!
-    \externalpage http://qt.digia.com/Services/training/
+    \externalpage http://www.qt.io/events/
     \title Qt Training Partners
 */
 /*!
-    \externalpage http://qt.digia.com/Services/training/
+    \externalpage http://www.qt.io/events/
     \title Open Enrollment Qt Training Courses
 */
 /*!
@@ -270,214 +270,210 @@
     \title external: Qt Mobility Examples
 */
 /*!
-    \externalpage http://qt-project.org/videos
+    \externalpage https://www.youtube.com/user/QtStudios
     \title Qt Video Portal
 */
 /*!
-    \externalpage http://qt-project.org/wiki/developer-guides
+    \externalpage https://wiki.qt.io/Developer-Guides
     \title Qt eLearning Training Materials
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch
+    \externalpage https://www.youtube.com/user/QtStudios
     \title Qt Developer Days 2010
 */
 /*!
-    \externalpage http://qt-project.org/wiki/Category:LanguageBindings
+    \externalpage https://wiki.qt.io/Category:LanguageBindings
     \title Qt Language Bindings on Wiki
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/qt_programming_essentials_by_ics_part_1
+    \externalpage https://www.youtube.com/user/QtStudios
     \title Qt Essentials by ICS part 1
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/qt_programming_essentials_by_ics_part_2
+    \externalpage https://www.youtube.com/user/QtStudios
     \title Qt Essentials by ICS part 2
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/qt_programming_essentials_by_kdab_part_1
+    \externalpage https://www.youtube.com/user/QtStudios
     \title Qt Essentials by KDAB part 1
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/qt_programming_essentials_by_kdab_part_2
+    \externalpage https://www.youtube.com/user/QtStudios
     \title Qt Essentials by KDAB part 2
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/programming_with_qt_qgraphicsview_by_ics
+    \externalpage https://www.youtube.com/user/QtStudios
     \title QGraphicsView by ICS
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/programming_with_qt_qgraphicsview_by_kdab
+    \externalpage https://www.youtube.com/user/QtStudios
     \title QGraphicsView by KDAB
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/programming_with_qt_multithreading_by_ics
+    \externalpage https://www.youtube.com/user/QtStudios
     \title Multithreading by ICS
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/programming_with_qt_multithreading_by_kdab
+    \externalpage https://www.youtube.com/user/QtStudios
     \title Multithreading by KDAB
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/training_teaser_ui_development_with_qt_by_ics
+    \externalpage https://www.youtube.com/user/QtStudios
     \title UI Development with Qt by ICS
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/training_teaser_ui_development_with_qt_by_kdab
+    \externalpage https://www.youtube.com/user/QtStudios
     \title UI Development with Qt by KDAB
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/training_teaser_embedded_development_by_basyskom
+    \externalpage https://www.youtube.com/user/QtStudios
     \title Embedded Development by basysKom
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/training_teaser_embedded_development_by_ics
+    \externalpage https://www.youtube.com/user/QtStudios
     \title Embedded Development by ICS
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/programming_with_qt_model_view_programming_by_basyskom
+    \externalpage https://www.youtube.com/user/QtStudios
     \title ModelView Programming by basysKom
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/programming_with_qt_model_view_programming_by_kdab
+    \externalpage https://www.youtube.com/user/QtStudios
     \title ModelView Programming by KDAB
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/programming_with_qt_webkit_by_kdab
+    \externalpage https://www.youtube.com/user/QtStudios
     \title QWebKit by KDAB
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/qt_quick_introduction_to_qt_quick_part_1_4
+    \externalpage https://www.youtube.com/watch?v=WBf9TbzHBfk
     \title Quick by KDAB part 1
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/qt_quick_user_interaction_user_input_and_states_part_2_4
+    \externalpage https://www.youtube.com/watch?v=CyNVvbMg888
     \title Quick by KDAB part 2
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/qt_quick_animations_and_visual_effects_part_3_4
+    \externalpage https://www.youtube.com/watch?v=rwLj-P2Oofw
     \title Quick by KDAB part 3
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/qt_quick_small_projects_arranging_items_qmlcomponentsand_debugging_qml_part
+    \externalpage https://www.youtube.com/watch?v=4rjhgMTShnM
     \title Quick by KDAB part 4
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/qt_mobile_development_for_nokia_devices_introduction_to_qt_on_mobile_part_1
+    \externalpage https://www.youtube.com/watch?v=7vsBANtYWUg
     \title Qt Mobile Development for Nokia Devices by Digia part 1
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/qt_mobile_development_for_nokia_devices_mobile_ui_design_technologies_and_a
+    \externalpage https://www.youtube.com/watch?v=WgXy1841Wwo
     \title Qt Mobile Development for Nokia Devices by Digia part 2
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/qt_mobile_development_for_nokia_devices_getting_started_with_nokia_qt_sdk_p
+    \externalpage https://www.youtube.com/watch?v=-qhBsfAqmyQ
     \title Qt Mobile Development for Nokia Devices by Digia part 3
 */
 
 /*!
-    \externalpage http://qt-project.org/videos/watch/qt_essentials_widget_edition_fundamentals_of_qt_part_2_hello_world_in_qtcre
+    \externalpage https://www.youtube.com/watch?v=HYBLfsO2Vng
     \title Qt Essentials - Fundamentals of Qt part 1
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/qt_essentials_widget_edition_fundamentals_of_qt_part_1_your_first_qt_applic
+    \externalpage https://www.youtube.com/watch?v=-h0F8-WjHV0
     \title Qt Essentials - Fundamentals of Qt part 2
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/qt_essentials_widget_edition_application_creation_part_1_mainwindows
+    \externalpage https://www.youtube.com/watch?v=z4RLrRK7420
     \title Qt Essentials - Application Creation part 1
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/application_creation_part_2_settings_resources_and_application_deployment
+    \externalpage https://www.youtube.com/watch?v=ZM6TQpEyyzA
     \title Qt Essentials - Application Creation part 2
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/application_creation_part_3_translation_for_developers
+    \externalpage https://www.youtube.com/watch?v=ew8fk3lLqbQ
     \title Qt Essentials - Application Creation part 3
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/widgets_part_1_common_widgets
+    \externalpage https://www.youtube.com/watch?v=Q1XGyPREbFg
     \title Qt Essentials - Widgets part 1
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/widgets_part_2_layout_management
+    \externalpage https://www.youtube.com/watch?v=VOGPOWz9nV0
     \title Qt Essentials - Widgets part 2
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/widgets_part_3_guidelines_for_custom_widgets
+    \externalpage https://www.youtube.com/watch?v=bGTJ63w_Csc
     \title Qt Essentials - Widgets part 3
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/graphics_view_part_1_using_graphicsview_classes
+    \externalpage https://www.youtube.com/watch?v=P9VG5LpU1lA
     \title Qt Essentials - Graphics View part 1
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/graphics_view_part_2_transformations_and_coordinate_systems
+    \externalpage https://www.youtube.com/watch?v=dj5550wsUG0
     \title Qt Essentials - Graphics View part 2
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/graphics_view_part_3_creating_custom_items
+    \externalpage https://www.youtube.com/watch?v=PbVcR_sCSNw
     \title Qt Essentials - Graphics View part 3
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/model_view_part_1_model_view_concept
+    \externalpage https://www.youtube.com/watch?v=T0HXWcpPItk
     \title Qt Essentials - Model/View I part 1
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/model_view_part_2_showing_simple_data
+    \externalpage https://www.youtube.com/watch?v=tuA8VK9nOFA
     \title Qt Essentials - Model/View I part 2
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/model_view_part_3_proxy_models
+    \externalpage https://www.youtube.com/watch?v=lEfzIt7lJ8M
     \title Qt Essentials - Model/View I part 3
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/model_view_part_4_custom_models
+    \externalpage https://www.youtube.com/watch?v=ytKDsJgJa4k
     \title Qt Essentials - Model/View I part 4
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/model_view_ii_part_1_editing_item_data
+    \externalpage https://www.youtube.com/watch?v=CX-cjj-U-mQ
     \title Qt Essentials - Model/View II part 1
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/model_view_ii_part_2_delegates
+    \externalpage https://www.youtube.com/watch?v=iBt2OYcFaIo
     \title Qt Essentials - Model/View II part 2
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/model_view_ii_part_3_data_widget_mapper
+    \externalpage https://www.youtube.com/watch?v=GFdW0VdJqw8
     \title Qt Essentials - Model/View II part 3
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/model_view_ii_part_4_custom_tree_model
+    \externalpage https://www.youtube.com/watch?v=dcrSTeVaW5Y
     \title Qt Essentials - Model/View II part 4
 */
 /*!
-    \externalpage http://qt-project.org/videos/watch/model_view_ii_part_5_drag_and_drop
+    \externalpage https://www.youtube.com/watch?v=d2OFjACLgOg
     \title Qt Essentials - Model/View II part 5
 */
 /*!
-    \externalpage http://qt.digia.com/Product/Learning/Certification/
+    \externalpage http://www.qt.io/qt-certification/
     \title Qt Certification
 */
 /*!
-    \externalpage http://qt.digia.com/Product/Learning/Certification/
+    \externalpage http://www.qt.io/qt-certification/
     \title Qt Certification Exam Preparation and Prerequisites
 */
 /*!
-    \externalpage http://qt.digia.com/Product/Learning/Certification/
-    \title Qt Certification
-*/
-/*!
-    \externalpage http://qt-project.org
+    \externalpage http://www.qt.io/developers/
     \title Qt Developer Network
 */
 
 /*!
-    \externalpage http://qt-project.org/wiki/Qt_Modules_Maturity_Level
+    \externalpage https://wiki.qt.io/Qt_Modules_Maturity_Level
     \title Qt Modules' Maturity Levels - Modules List
 */
 
 /*!
-    \externalpage http://blog.qt.digia.com/2011/05/03/qt-modules-maturity-level/
+    \externalpage http://blog.qt.io/blog/2011/05/03/qt-modules-maturity-level/
     \title Qt Modules' Maturity Level - Description
 */
 

--- a/doc/src/qt4-intro.qdoc
+++ b/doc/src/qt4-intro.qdoc
@@ -220,7 +220,7 @@
     \endlist
 
     For more information about improvements in each Qt release, see
-    the \l{http://qt.nokia.com/developer/changes/}
+    the \l{http://code.qt.io/cgit/qt/qt.git/tree/dist}
     {detailed lists of changes}.
 
     \section1 Significant Improvements
@@ -660,7 +660,7 @@
 
     Qt 4.7 adds support for accelerated compositing, which enhances
     the performance of CSS animations and transitions. Read more in
-    \l{http://labs.trolltech.com/blogs/2010/05/17/qtwebkit-now-accelerates-css-animations-3d-transforms/}{this blog}.
+    \l{http://blog.qt.io/blog/2010/05/17/qtwebkit-now-accelerates-css-animations-3d-transforms/}{this blog}.
 
     For hybrid QtWebKit and C++ projects, Qt 4.7 has added support for
     transporting \l{QPixmap}s between Qt C++ and WebKit. We have also
@@ -702,7 +702,7 @@
 
     Qt 4.7 introduces the QStaticText class, which can be used to
     improve text rendering performance.  More info is available from
-    \l{http://labs.trolltech.com/blogs/2010/03/01/insanity-is-shaping-the-same-text-again-and-expecting-a-different-result/}{this blog}.
+    \l{http://blog.qt.io/blog/2010/03/01/insanity-is-shaping-the-same-text-again-and-expecting-a-different-result/}{this blog}.
 
     The QPainter class has a new API for rendering pixmap fragments
     (QPainter::drawPixmapFragments), which can improve the rendering
@@ -731,13 +731,13 @@
 \omit
     A comprehensive list of changes between Qt 4.5 and Qt 4.6 is
     included in the \c changes-4.6.0 file
-    \l{http://qt.nokia.com/developer/changes/changes-4.6.0}{available
+    \l{http://code.qt.io/cgit/qt/qt.git/plain/dist/changes-4.6.0}{available
     online}. A \l{Known Issues in %VERSION%}{list of known issues}
     for this release is also available.
 
     Changes between this release and the previous release are provided
     in the \c{changes-%VERSION%} file (also
-    \l{http://qt.nokia.com/developer/changes/changes-%VERSION%}{available online}).
+    \l{http://code.qt.io/cgit/qt/qt.git/plain/dist/changes-%VERSION%}{available online}).
 \endomit
 
     A list of other Qt 4 features can be found on the \bold{\l{What's
@@ -941,13 +941,13 @@
 
     A comprehensive list of changes between Qt 4.4 and Qt 4.5 is included
     in the \c changes-4.5.0 file
-    \l{http://qt.nokia.com/developer/changes/changes-4.5.0}{available online}.
+    \l{http://code.qt.io/cgit/qt/qt.git/plain/dist/changes-4.5.0}{available online}.
     A \l{Known Issues in %VERSION%}{list of known issues} for this release is also
     available.
 
     Changes between this release and the previous release are provided
     in the \c{changes-%VERSION%} file (also
-    \l{http://qt.nokia.com/developer/changes/changes-%VERSION%}{available online}).
+    \l{http://code.qt.io/cgit/qt/qt.git/plain/dist/changes-%VERSION%}{available online}).
 
     A list of other Qt 4 features can be found on the
     \bold{\l{What's New in Qt 4}} page.

--- a/doc/src/widgets-and-layouts/layout.qdoc
+++ b/doc/src/widgets-and-layouts/layout.qdoc
@@ -255,7 +255,7 @@
 
     For further guidance when implementing these functions, see the
     \e{Qt Quarterly} article
-    \l{http://doc.qt.nokia.com/qq/qq04-height-for-width.html}
+    \l{http://doc.qt.digia.com/qq/qq04-height-for-width.html}
     {Trading Height for Width}.
 
 

--- a/doc/src/xml-processing/xquery-introduction.qdoc
+++ b/doc/src/xml-processing/xquery-introduction.qdoc
@@ -743,7 +743,7 @@ You can also ask questions on XQuery mail lists:
 
 \list
 \o
-\l{http://qt.nokia.com/lists/qt-interest/}{qt-interest}
+\l{http://lists.qt-project.org/mailman/listinfo/interest}{qt-interest}
 \o
 \l{http://www.x-query.com/mailman/listinfo/talk}{talk at x-query.com}.
 \endlist

--- a/src/3rdparty/webkit/Source/WebKit/qt/docs/qtwebkit-goes-mobile.qdoc
+++ b/src/3rdparty/webkit/Source/WebKit/qt/docs/qtwebkit-goes-mobile.qdoc
@@ -68,7 +68,7 @@
     just scale the existing tiles. Then, at the end of the animation, update
     tiles on top of the scaled ones.  For now we will ignore the blocking
     issue and concentrate on the tiling and the interaction model.
-    More information about Tiling can be found here: \l{http://doc.qt.nokia.com/4.7/qwebsettings.html#WebAttribute-enum} (see the entry for TiledBackingStoreEnabled).
+    More information about Tiling can be found here: \l{http://doc.qt.io/qt-4.8/qwebsettings.html#WebAttribute-enum} (see the entry for TiledBackingStoreEnabled).
 
 
     \section1 Resize to Contents

--- a/src/corelib/global/qnamespace.qdoc
+++ b/src/corelib/global/qnamespace.qdoc
@@ -2757,10 +2757,10 @@
     \value ElideNone    Ellipsis should NOT appear in the text.
 
     Qt::ElideMiddle is normally the most appropriate choice for URLs (e.g.,
-    "\l{http://bugreports.qt-project.org/browse/QTWEBSITE-13}{http://bugreports.qt.../QTWEBSITE-13/}"),
+    "\l{http://bugreports.qt.io/browse/QTWEBSITE-13}{http://bugreports.qt.../QTWEBSITE-13/}"),
     whereas Qt::ElideRight is appropriate
     for other strings (e.g.,
-    "\l{http://qt.nokia.com/doc/qq/qq09-mac-deployment.html}{Deploying Applications on Ma...}").
+    "\l{http://doc.qt.digia.com/qq/qq09-mac-deployment.html}{Deploying Applications on Ma...}").
 
     \sa QAbstractItemView::textElideMode, QFontMetrics::elidedText(), AlignmentFlag QTabBar::elideMode
 */

--- a/src/gui/dialogs/qwizard.cpp
+++ b/src/gui/dialogs/qwizard.cpp
@@ -3636,7 +3636,7 @@ bool QWizardPage::validatePage()
     from the rest of your implementation, whenever the value of isComplete()
     changes. This ensures that QWizard updates the enabled or disabled state of
     its buttons. An example of the reimplementation is
-    available \l{http://qt.nokia.com/doc/qq/qq22-qwizard.html#validatebeforeitstoolate}
+    available \l{http://doc.qt.digia.com/qq/qq22-qwizard.html#validatebeforeitstoolate}
     {here}.
 
     \sa completeChanged(), isFinalPage()

--- a/src/gui/image/qimagereader.cpp
+++ b/src/gui/image/qimagereader.cpp
@@ -1480,7 +1480,7 @@ QByteArray QImageReader::imageFormat(QIODevice *device)
     \l{QtSvg Module}{SVG Module}.
 
     TGA support only extends to reading non-RLE compressed files.  In particular
-    calls to \l{http://doc.qt.nokia.com/4.7-snapshot/qimageioplugin.html#capabilities}{capabilities}
+    calls to \l{http://doc.qt.io/qt-4.8/qimageioplugin.html#capabilities}{capabilities}
     for the tga plugin returns only QImageIOPlugin::CanRead, not QImageIOPlugin::CanWrite.
 
     To configure Qt with GIF support, pass \c -qt-gif to the \c

--- a/src/gui/image/qpixmapcache.cpp
+++ b/src/gui/image/qpixmapcache.cpp
@@ -84,7 +84,7 @@ QT_BEGIN_NAMESPACE
     memory.
 
     The \e{Qt Quarterly} article
-    \l{http://qt.nokia.com/doc/qq/qq12-qpixmapcache.html}{Optimizing
+    \l{http://doc.qt.digia.com/qq/qq12-qpixmapcache.html}{Optimizing
     with QPixmapCache} explains how to use QPixmapCache to speed up
     applications by caching the results of painting.
 

--- a/src/gui/kernel/qlayoutitem.cpp
+++ b/src/gui/kernel/qlayoutitem.cpp
@@ -107,7 +107,7 @@ QSizePolicy::operator QVariant() const
     be expressed using hasHeightForWidth(), heightForWidth(), and
     minimumHeightForWidth(). For more explanation see the \e{Qt
     Quarterly} article
-    \l{http://qt.nokia.com/doc/qq/qq04-height-for-width.html}{Trading
+    \l{http://doc.qt.digia.com/qq/qq04-height-for-width.html}{Trading
     Height for Width}.
 
     \sa QLayout

--- a/tools/qdoc3/doc/files/qt.qdocconf
+++ b/tools/qdoc3/doc/files/qt.qdocconf
@@ -8,7 +8,7 @@ project                 = Qt
 versionsym              =
 version                 = %VERSION%
 description             = Qt Reference Documentation
-url                     = http://qt.nokia.com/doc/4.8
+url                     = http://doc.qt.io/qt-4.8
 
 edition.Console.modules = QtCore QtDBus QtNetwork QtScript QtSql QtXml \
                           QtXmlPatterns QtTest

--- a/tools/qdoc3/test/assistant.qdocconf
+++ b/tools/qdoc3/test/assistant.qdocconf
@@ -6,7 +6,7 @@ include(qt-defines.qdocconf)
 
 project                 = Qt Assistant
 description             = Qt Assistant Manual
-url                     = http://doc.qt.nokia.com/4.8/
+url                     = http://doc.qt.io/qt-4.8/
 
 indexes                 = $QT_BUILD_TREE/doc-build/html-qt/qt.index
 

--- a/tools/qdoc3/test/designer.qdocconf
+++ b/tools/qdoc3/test/designer.qdocconf
@@ -6,7 +6,7 @@ include(qt-defines.qdocconf)
 
 project                 = Qt Designer
 description             = Qt Designer Manual
-url                     = http://doc.qt.nokia.com/4.8/
+url                     = http://doc.qt.io/qt-4.8/
 
 indexes                 = $QT_BUILD_TREE/doc-build/html-qt/qt.index
 

--- a/tools/qdoc3/test/linguist.qdocconf
+++ b/tools/qdoc3/test/linguist.qdocconf
@@ -6,7 +6,7 @@ include(qt-defines.qdocconf)
 
 project                 = Qt Linguist
 description             = Qt Linguist Manual
-url                     =  http://doc.qt.nokia.com/4.8/
+url                     =  http://doc.qt.io/qt-4.8/
 
 indexes                 = $QT_BUILD_TREE/doc-build/html-qt/qt.index
 

--- a/tools/qdoc3/test/qdeclarative.qdocconf
+++ b/tools/qdoc3/test/qdeclarative.qdocconf
@@ -6,7 +6,7 @@ include(qt-defines.qdocconf)
 
 project                 = Qml
 description             = Qml Reference Documentation
-url                     = http://qt.nokia.com/doc/4.8/
+url                     = http://doc.qt.io/qt-4.8/
 qmlonly                 = true
 
 edition.Console.modules = QtCore QtDBus QtNetwork QtScript QtSql QtXml \

--- a/tools/qdoc3/test/qmake.qdocconf
+++ b/tools/qdoc3/test/qmake.qdocconf
@@ -6,7 +6,7 @@ include(qt-defines.qdocconf)
 
 project                 = QMake
 description             = QMake Manual
-url                     = http://qt.nokia.com/doc/4.8
+url                     = http://doc.qt.io/qt-4.8
 
 indexes                 = $QT_BUILD_TREE/doc-build/html-qt/qt.index
 

--- a/tools/qdoc3/test/qt-project.qdocconf
+++ b/tools/qdoc3/test/qt-project.qdocconf
@@ -5,7 +5,7 @@ include(qt-defines.qdocconf)
 
 project                 = Qt
 description             = Qt Reference Documentation
-url                     = http://qt.nokia.com/doc/4.8
+url                     = http://doc.qt.io/qt-4.8
 version                 = 4.8.7
 
 sourceencoding          = UTF-8

--- a/translations/README
+++ b/translations/README
@@ -2,5 +2,5 @@ All translations are contributed by the Qt community.
 They are provided without guarantees, will often be stale, and may even
 disappear entirely from future Qt releases.
 
-See http://qt-project.org/wiki/Qt-Localization for information on how to
+See https://wiki.qt.io/Qt-Localization for information on how to
 contribute translations.


### PR DESCRIPTION
Update external URLs in the documentation for links where the
resource is still available online.

Change-Id: I99e5d6d7e030f93c3fe8d31cf300077e2897649e
Reviewed-by: Friedemann Kleint <Friedemann.Kleint@theqtcompany.com>